### PR TITLE
Added missing header file

### DIFF
--- a/initializetask.cpp
+++ b/initializetask.cpp
@@ -9,6 +9,7 @@ extern "C" {
 
 #include <string>
 #include <iostream>
+#include <random>
 
 void initializeTask::help()
 {


### PR DESCRIPTION
Fixes compilation error
`initializetask.cpp:62:8: error: ‘random_device’ is not a member of ‘std’`
by adding the random header file. This is a fix for issue [https://github.com/nthdimtech/signet-cli/issues/4](https://github.com/nthdimtech/signet-cli/issues/4).