### PR TITLE
Use absolute URLs for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "signet-base"]
 	path = signet-base
-	url = ../signet-base.git
+	url = https://github.com/nthdimtech/signet-base.git


### PR DESCRIPTION
With relative URLs if I want to fork signet-client on my profile, I'll have to fork every relative submodule as well.